### PR TITLE
SUP-5: traceId 로깅, 표준 응답/예외, CORS 설정, Actuator/Swagger & 통합테스트 추가

### DIFF
--- a/suppingmall/api/pom.xml
+++ b/suppingmall/api/pom.xml
@@ -35,6 +35,14 @@
       <version>2.8.9</version>
     </dependency>
 
+    <!-- lombok -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.38</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- actuator -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -56,6 +64,32 @@
         <configuration>
           <mainClass>com.supshop.suppingmall.api.SuppingmallApiApplication</mainClass>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>${java.version}</release> <!-- 23 -->
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.38</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+        <!-- (선택) 테스트 컴파일에도 확실히 적용하고 싶으면 executions 추가 -->
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <goals><goal>compile</goal></goals>
+          </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals><goal>testCompile</goal></goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/ApiError.java
+++ b/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/ApiError.java
@@ -1,0 +1,3 @@
+package com.supshop.suppingmall.api.common;
+
+public record ApiError(String code, String message) {}

--- a/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/ApiResponse.java
+++ b/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/ApiResponse.java
@@ -1,0 +1,10 @@
+package com.supshop.suppingmall.api.common;
+
+public record ApiResponse<T>(boolean success, T data, ApiError error, String traceId) {
+    public static <T> ApiResponse<T> ok(T data, String traceId) {
+        return new ApiResponse<>(true, data, null, traceId);
+    }
+    public static ApiResponse<Void> fail(ApiError error, String traceId) {
+        return new ApiResponse<>(false, null, error, traceId);
+    }
+}

--- a/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/GlobalExceptionHandler.java
+++ b/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.supshop.suppingmall.api.common;
+
+import jakarta.validation.ConstraintViolationException;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.List;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidation(MethodArgumentNotValidException ex) {
+        String traceId = MDC.get("traceId");
+        List<Map<String,Object>> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> Map.<String,Object>of(
+                        "field", fe.getField(),
+                        "message", fe.getDefaultMessage(),
+                        "rejected", fe.getRejectedValue()))
+                .toList();
+        return ResponseEntity.badRequest().body(
+                ApiResponse.fail(new ApiError("VALIDATION_ERROR", errors.toString()), traceId)
+        );
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> handleConstraint(ConstraintViolationException ex) {
+        String traceId = MDC.get("traceId");
+        return ResponseEntity.badRequest().body(
+                ApiResponse.fail(new ApiError("CONSTRAINT_VIOLATION", ex.getMessage()), traceId)
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleGeneric(Exception ex) {
+        String traceId = MDC.get("traceId");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                ApiResponse.fail(new ApiError("INTERNAL_SERVER_ERROR", ex.getMessage()), traceId)
+        );
+    }
+}

--- a/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/RequestLoggingFilter.java
+++ b/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/RequestLoggingFilter.java
@@ -1,0 +1,34 @@
+package com.supshop.suppingmall.api.common;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+        long start = System.currentTimeMillis();
+        String traceId = req.getHeader("X-Request-Id");
+        if (!StringUtils.hasText(traceId)) traceId = UUID.randomUUID().toString();
+        MDC.put("traceId", traceId);
+        res.setHeader("X-Request-Id", traceId);
+        try {
+            chain.doFilter(req, res);
+        } finally {
+            long took = System.currentTimeMillis() - start;
+            log.info("[{}] {} {} -> {} ({}ms)", traceId, req.getMethod(), req.getRequestURI(), res.getStatus(), took);
+            MDC.remove("traceId");
+        }
+    }
+}

--- a/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/ResponseWrappingAdvice.java
+++ b/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/ResponseWrappingAdvice.java
@@ -1,0 +1,28 @@
+package com.supshop.suppingmall.api.common;
+
+import org.slf4j.MDC;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ResponseWrappingAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter mp, Class<? extends HttpMessageConverter<?>> c) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter mp, MediaType t,
+                                  Class<? extends HttpMessageConverter<?>> c,
+                                  ServerHttpRequest req, ServerHttpResponse res) {
+        if (body instanceof ApiResponse<?> || body instanceof String || body instanceof byte[]) return body;
+        String traceId = MDC.get("traceId");
+        return ApiResponse.ok(body, traceId);
+    }
+}

--- a/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/WebConfig.java
+++ b/suppingmall/api/src/main/java/com/supshop/suppingmall/api/common/WebConfig.java
@@ -1,0 +1,32 @@
+package com.supshop.suppingmall.api.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Value("${app.cors.allowed-origins:*}")
+    private String[] allowedOrigins;
+
+    @Bean
+    public RequestLoggingFilter requestLoggingFilter() {
+        return new RequestLoggingFilter();
+    }
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins(allowedOrigins)
+                        .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/suppingmall/api/src/main/resources/application.yml
+++ b/suppingmall/api/src/main/resources/application.yml
@@ -4,6 +4,14 @@ spring:
 server:
   port: 8080
 
+app:
+  cors:
+    allowed-origins: "http://localhost:3000,http://127.0.0.1:3000"   # 프론트 도메인 생기면 교체
+
+logging:
+  level:
+    org.springdoc: DEBUG
+
 springdoc:
   api-docs.path: /api/v1/openapi
   swagger-ui.path: /api/v1/swagger

--- a/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/CorsTest.java
+++ b/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/CorsTest.java
@@ -1,0 +1,31 @@
+package com.supshop.suppingmall.api.common;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CorsTest {
+    @LocalServerPort int port;
+    @Autowired TestRestTemplate rest;
+
+    @Test
+    void preflight_shouldReturnOK() {
+        HttpHeaders h = new HttpHeaders();
+        h.setOrigin("http://localhost:3000");
+        h.setAccessControlRequestMethod(HttpMethod.GET);
+        ResponseEntity<String> res = rest.exchange(
+                "http://localhost:"+port+"/api/v1/health",
+                HttpMethod.OPTIONS, new HttpEntity<>(h), String.class);
+        assertThat(res.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(res.getHeaders().getAccessControlAllowOrigin()).isEqualTo("http://localhost:3000");
+    }
+}

--- a/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/GlobalExceptionTest.java
+++ b/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/GlobalExceptionTest.java
@@ -1,0 +1,37 @@
+package com.supshop.suppingmall.api.common;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(GlobalExceptionHandlerTest.TestController.class)
+class GlobalExceptionHandlerTest {
+
+    @LocalServerPort int port;
+    @Autowired TestRestTemplate rest;
+    private String url(String p){ return "http://localhost:"+port+p; }
+
+    @RestController
+    @RequestMapping("/api/t")
+    static class TestController {
+        @GetMapping("/boom")
+        Map<String,Object> boom(){ throw new RuntimeException("boom"); }
+    }
+
+    @Test
+    void genericError_shouldReturn500_withCode() {
+        ResponseEntity<String> res = rest.getForEntity(url("/api/t/boom"), String.class);
+        assertThat(res.getStatusCode().value()).isEqualTo(500);
+        assertThat(res.getBody()).contains("\"success\":false").contains("\"code\":\"INTERNAL_SERVER_ERROR\"");
+    }
+}

--- a/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/RequestLoggingFilterTest.java
+++ b/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/RequestLoggingFilterTest.java
@@ -1,0 +1,42 @@
+package com.supshop.suppingmall.api.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(RequestLoggingFilterTest.TestController.class)
+class RequestLoggingFilterTest {
+    @LocalServerPort int port;
+    @Autowired TestRestTemplate rest;
+    private String url(String p){ return "http://localhost:"+port+p; }
+
+    @RestController
+    @RequestMapping("/api/t")
+    static class TestController {
+        @GetMapping("/echo")
+        Map<String,Object> echo(){ return Map.of("echo","ok"); }
+    }
+
+    @Test
+    void shouldLogEachRequest(CapturedOutput output) {
+        rest.getForEntity(url("/api/t/echo"), String.class);
+        assertThat(output.getOut())
+                .contains("GET /api/t/echo")
+                .contains("-> 200");
+    }
+}

--- a/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/ResponseWrappingAdviceTest.java
+++ b/suppingmall/api/src/test/java/com/supshop/suppingmall/api/common/ResponseWrappingAdviceTest.java
@@ -1,0 +1,81 @@
+package com.supshop.suppingmall.api.common;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = { "management.endpoints.web.exposure.include=health,info" }
+)
+@Import(ResponseWrappingAdviceTest.TestController.class)
+class ResponseWrappingAdviceTest {
+
+    @LocalServerPort int port;
+    @Autowired TestRestTemplate rest;
+    String url(String p){ return "http://localhost:"+port+p; }
+
+    @RestController
+    @RequestMapping("/api/t")
+    static class TestController {
+        record Req(@NotBlank String name) {}
+
+        @GetMapping("/echo")
+        Map<String,Object> echo(){ return Map.of("echo","ok"); }
+
+        @PostMapping("/validate")
+        Map<String,Object> v(@Valid @RequestBody Req r){ return Map.of("name", r.name()); }
+
+        @GetMapping("/boom")
+        Map<String,Object> boom(){ throw new RuntimeException("boom"); }
+    }
+
+    @Test
+    void normalApi_shouldBeWrapped() {
+        ResponseEntity<String> res = rest.getForEntity(url("/api/t/echo"), String.class);
+        assertThat(res.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(res.getBody())
+                .contains("\"success\":true")
+                .contains("\"data\"")
+                .contains("\"traceId\"");
+    }
+
+    @Test
+    void validationError_shouldReturn400_withStandardError() {
+        HttpHeaders h = new HttpHeaders(); h.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> res = rest.postForEntity(
+                url("/api/t/validate"), new HttpEntity<>("{\"name\":\"\"}", h), String.class);
+
+        assertThat(res.getStatusCode().value()).isEqualTo(400);
+        assertThat(res.getBody())
+                .contains("\"success\":false")
+                .contains("\"code\""); // VALIDATION_.. 코드 문자열 포함 여부는 구현에 맞게 조정
+    }
+
+    @Test
+    void genericError_shouldReturn500_withStandardError() {
+        ResponseEntity<String> res = rest.getForEntity(url("/api/t/boom"), String.class);
+        assertThat(res.getStatusCode().value()).isEqualTo(500);
+        assertThat(res.getBody())
+                .contains("\"success\":false")
+                .contains("\"code\":\"INTERNAL_SERVER_ERROR\"");
+    }
+}


### PR DESCRIPTION
- traceId 로깅
- 표준 응답/예외
  ```json
   // 성공 200 OK
   {
      "success": true,
      "data": { ...실제 응답 바디... },
      "error": null,
      "traceId": "e9ff720b-...."
    }
   // 실패 400 ERROR
   {
      "success": false,
      "data": null,
      "error": {
        "code": "VALIDATION_ERROR",
        "message": "[{field=name, message=must not be blank, rejected=}]"
       },
      "traceId": "e9ff720b-...."
    }
   ```
- CORS 설정
- 전체 통합 테스트 추가